### PR TITLE
x64 version

### DIFF
--- a/NPPXmlTreeview.sln
+++ b/NPPXmlTreeview.sln
@@ -22,33 +22,47 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x64.ActiveCfg = Debug|x64
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x64.Build.0 = Debug|x64
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x86.Build.0 = Debug|Any CPU
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x64.ActiveCfg = Release|x64
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x64.Build.0 = Release|x64
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x86.ActiveCfg = Release|Any CPU
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x86.Build.0 = Release|Any CPU
 		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Debug|x64.ActiveCfg = Debug|x64
+		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Debug|x64.Build.0 = Debug|x64
 		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Debug|x86.Build.0 = Debug|Any CPU
 		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Release|x64.ActiveCfg = Release|x64
+		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Release|x64.Build.0 = Release|x64
 		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Release|x86.ActiveCfg = Release|Any CPU
 		{EABA4132-6E8C-41EC-B6F0-666EFCA5439A}.Release|x86.Build.0 = Release|Any CPU
 		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Debug|x64.ActiveCfg = Debug|x64
+		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Debug|x64.Build.0 = Debug|x64
 		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Debug|x86.Build.0 = Debug|Any CPU
 		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Release|x64.ActiveCfg = Release|x64
+		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Release|x64.Build.0 = Release|x64
 		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Release|x86.ActiveCfg = Release|Any CPU
 		{8528055D-DBCD-4875-AC86-B40FF06345B1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,11 @@
 version: 1.5.0.{build}
 skip_tags: true
 os: Visual Studio 2015
+
+platform:
+    - x86
+    - x64
+
 configuration: Release
 assembly_info:
   patch: true
@@ -14,9 +19,15 @@ before_build:
 build:
   verbosity: minimal
 after_build:
-- ps: 7z a NppXMLTreeviewPlugin.zip c:\projects\NppXmlTreeview\src\NppXmlTreeviewPlugin\bin\Release\NppXmlTreeviewPlugin.dll c:\projects\NppXmlTreeview\src\NppXmlTreeviewPlugin\bin\Release\NppXmlTreeviewPlugin
+- ps: >-
+    if ($env:PLATFORM -eq "x64") {
+        7z a NppXMLTreeviewPlugin_$env:PLATFORM.zip c:\projects\NppXmlTreeview\src\NppXmlTreeviewPlugin\bin\$env:PLATFORM\Release\NppXmlTreeviewPlugin.dll c:\projects\NppXmlTreeview\src\NppXmlTreeviewPlugin\bin\$env:PLATFORM\Release\NppXmlTreeviewPlugin
+    }
+    if ($env:PLATFORM -eq "x86") {
+        7z a NppXMLTreeviewPlugin_$env:PLATFORM.zip c:\projects\NppXmlTreeview\src\NppXmlTreeviewPlugin\bin\Release\NppXmlTreeviewPlugin.dll c:\projects\NppXmlTreeview\src\NppXmlTreeviewPlugin\bin\Release\NppXmlTreeviewPlugin
+    }
 artifacts:
-- path: NppXmlTreeviewPlugin.zip
+- path: NppXmlTreeviewPlugin_*.zip
   name: nppxmltreeview
 deploy:
 - provider: GitHub

--- a/src/NppXmlTreeviewPlugin.Parsers/NppXmlTreeviewPlugin.Parsers.csproj
+++ b/src/NppXmlTreeviewPlugin.Parsers/NppXmlTreeviewPlugin.Parsers.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NppXmlTreeviewPlugin.Parsers</RootNamespace>
     <AssemblyName>NppXmlTreeviewPlugin.Parsers</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -29,6 +29,24 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/NppXmlTreeviewPlugin/NppPluginNETHelper.cs
+++ b/src/NppXmlTreeviewPlugin/NppPluginNETHelper.cs
@@ -74,17 +74,17 @@ namespace NppPluginNET
                 RtlMoveMemory(newPointer, _nativePointer, oldSize);
                 Marshal.FreeHGlobal(_nativePointer);
             }
-            IntPtr ptrPosNewItem = (IntPtr)((int)newPointer + oldSize);
+            IntPtr ptrPosNewItem = (IntPtr)(newPointer.ToInt64() + oldSize);
             byte[] aB = Encoding.Unicode.GetBytes(funcItem._itemName + "\0");
             Marshal.Copy(aB, 0, ptrPosNewItem, aB.Length);
-            ptrPosNewItem = (IntPtr)((int)ptrPosNewItem + 128);
+            ptrPosNewItem = (IntPtr)(ptrPosNewItem.ToInt64() + 128);
             IntPtr p = (funcItem._pFunc != null) ? Marshal.GetFunctionPointerForDelegate(funcItem._pFunc) : IntPtr.Zero;
             Marshal.WriteIntPtr(ptrPosNewItem, p);
-            ptrPosNewItem = (IntPtr)((int)ptrPosNewItem + IntPtr.Size);
+            ptrPosNewItem = (IntPtr)(ptrPosNewItem.ToInt64() + IntPtr.Size);
             Marshal.WriteInt32(ptrPosNewItem, funcItem._cmdID);
-            ptrPosNewItem = (IntPtr)((int)ptrPosNewItem + 4);
+            ptrPosNewItem = (IntPtr)(ptrPosNewItem.ToInt64() + 4);
             Marshal.WriteInt32(ptrPosNewItem, Convert.ToInt32(funcItem._init2Check));
-            ptrPosNewItem = (IntPtr)((int)ptrPosNewItem + 4);
+            ptrPosNewItem = (IntPtr)(ptrPosNewItem.ToInt64() + 4);
             if (funcItem._pShKey._key != 0)
             {
                 IntPtr newShortCutKey = Marshal.AllocHGlobal(4);
@@ -103,15 +103,15 @@ namespace NppPluginNET
             {
                 FuncItem updatedItem = new FuncItem();
                 updatedItem._itemName = _funcItems[i]._itemName;
-                ptrPosItem = (IntPtr)((int)ptrPosItem + 128);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + 128);
                 updatedItem._pFunc = _funcItems[i]._pFunc;
-                ptrPosItem = (IntPtr)((int)ptrPosItem + IntPtr.Size);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + IntPtr.Size);
                 updatedItem._cmdID = Marshal.ReadInt32(ptrPosItem);
-                ptrPosItem = (IntPtr)((int)ptrPosItem + 4);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + 4);
                 updatedItem._init2Check = _funcItems[i]._init2Check;
-                ptrPosItem = (IntPtr)((int)ptrPosItem + 4);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + 4);
                 updatedItem._pShKey = _funcItems[i]._pShKey;
-                ptrPosItem = (IntPtr)((int)ptrPosItem + IntPtr.Size);
+                ptrPosItem = (IntPtr)(ptrPosItem.ToInt64() + IntPtr.Size);
 
                 _funcItems[i] = updatedItem;
             }

--- a/src/NppXmlTreeviewPlugin/NppXmlTreeviewPlugin.csproj
+++ b/src/NppXmlTreeviewPlugin/NppXmlTreeviewPlugin.csproj
@@ -10,7 +10,7 @@
     <RootNamespace>NppXmlTreeviewPlugin</RootNamespace>
     <AssemblyName>NppXmlTreeviewPlugin</AssemblyName>
     <OutputPath>bin\Debug\</OutputPath>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>
@@ -38,6 +38,26 @@
     <PlatformTarget>x86</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/tests/NppXmlTreeviewPlugin.Tests/NppXmlTreeviewPlugin.Tests.csproj
+++ b/tests/NppXmlTreeviewPlugin.Tests/NppXmlTreeviewPlugin.Tests.csproj
@@ -35,6 +35,24 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
- adapted the appveyor.yml config for x64 builds
- added x64 build target, with  #x64 fix for https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net/commit/69f2d6c94c045dcfc42b970bbe4758ead3efa9e7
- x64 seems to need .net framework 4.0 to produce a startable dll