### PR TITLE
package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,35 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        build_configuration: [Release, Debug]
+        build_platform: [x64, x86]
+        
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Setup NuGet.exe
+      uses: nuget/setup-nuget@v1
+
+    - name: Restore
+      working-directory: .
+      run: nuget restore NPPXmlTreeview.sln
+
+    - name: MSBuild of solution
+      working-directory: .
+      run: msbuild NPPXmlTreeview.sln /m /verbosity:minimal /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+
+

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
-#tool "nuget:?package=GitVersion.CommandLine"
-#tool "nuget:?package=xunit.runner.console&version=2.3.1"
+#tool "nuget:?package=GitVersion.CommandLine&version=5.6.3"
+#tool "nuget:?package=xunit.runner.console&version=2.4.1"
 #addin "nuget:?package=Cake.DependenciesAnalyser&version=2.0.0"
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -30,10 +30,10 @@ var artifactsDir = Directory("./artifacts");
 // VERBOSITY
 var msBuildVerbosity = Cake.Core.Diagnostics.Verbosity.Diagnostic;
 if (!Enum.TryParse(verbosity, true, out msBuildVerbosity))
-{	
+{
 	Warning(
-		"Verbosity could not be parsed into type 'Cake.Core.Diagnostics.Verbosity'. Defaulting to {0}", 
-		msBuildVerbosity); 
+		"Verbosity could not be parsed into type 'Cake.Core.Diagnostics.Verbosity'. Defaulting to {0}",
+		msBuildVerbosity);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -42,7 +42,7 @@ if (!Enum.TryParse(verbosity, true, out msBuildVerbosity))
 
 void Test(string testDllGlob)
 {
-	var settings = new XUnit2Settings();	
+	var settings = new XUnit2Settings();
 
 	Information("Testing '{0}'...",  testDllGlob);
 	XUnit2(testDllGlob, settings);
@@ -51,12 +51,12 @@ void Test(string testDllGlob)
 
 void Build(PlatformTarget platformTarget)
 {
-	var settings = new MSBuildSettings 
+	var settings = new MSBuildSettings
 	{
 		Verbosity = msBuildVerbosity,
 		Configuration = configuration,
 		PlatformTarget = platformTarget,
-		ToolVersion = MSBuildToolVersion.VS2015
+		ToolVersion = MSBuildToolVersion.VS2017
 	};
 
 	foreach(var solution in solutions)
@@ -71,38 +71,38 @@ void Pack(string directory, string outputFile)
 {
 	var directoryToClean = string.Format("{0}*.pdb", directory);
 
-    Information("Cleaning '{0}'...", directoryToClean);
-	DeleteFiles(directoryToClean);	
-    Information("'{0}' has been cleaned.", directoryToClean);
+	Information("Cleaning '{0}'...", directoryToClean);
+	DeleteFiles(directoryToClean);
+	Information("'{0}' has been cleaned.", directoryToClean);
 
 	directoryToClean = string.Format("{0}*.xml", directory);
 
-    Information("Cleaning '{0}'...", directoryToClean);
-	DeleteFiles(directoryToClean);	
-    Information("'{0}' has been cleaned.", directoryToClean);
+	Information("Cleaning '{0}'...", directoryToClean);
+	DeleteFiles(directoryToClean);
+	Information("'{0}' has been cleaned.", directoryToClean);
 
-    Information("Compressing '{0}' to '{1}'...", directory, outputFile);
-	Zip(directory, outputFile);	
-    Information("'{0}' has been compressed to '{1}'.", directory, outputFile);
+	Information("Compressing '{0}' to '{1}'...", directory, outputFile);
+	Zip(directory, outputFile);
+	Information("'{0}' has been compressed to '{1}'.", directory, outputFile);
 }
 
 void CopyPlugin(string source, string destination)
 {
 	var directoryToClean = string.Format("{0}*.pdb", source);
 
-    Information("Cleaning '{0}'...", directoryToClean);
-	DeleteFiles(directoryToClean);	
-    Information("'{0}' has been cleaned.", directoryToClean);
+	Information("Cleaning '{0}'...", directoryToClean);
+	DeleteFiles(directoryToClean);
+	Information("'{0}' has been cleaned.", directoryToClean);
 
 	directoryToClean = string.Format("{0}*.xml", source);
 
-    Information("Cleaning '{0}'...", directoryToClean);
-	DeleteFiles(directoryToClean);	
-    Information("'{0}' has been cleaned.", directoryToClean);
+	Information("Cleaning '{0}'...", directoryToClean);
+	DeleteFiles(directoryToClean);
+	Information("'{0}' has been cleaned.", directoryToClean);
 
-    Information("Copying '{0}' to '{1}'...", source, destination);
-	CopyDirectory(source, destination);	
-    Information("'{0}' has been copied to '{1}'.", source, destination);
+	Information("Copying '{0}' to '{1}'...", source, destination);
+	CopyDirectory(source, destination);
+	Information("'{0}' has been copied to '{1}'.", source, destination);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -111,15 +111,15 @@ void CopyPlugin(string source, string destination)
 
 Setup(ctx =>
 {
-    // Executed BEFORE the first task.
+	// Executed BEFORE the first task.
 	EnsureDirectoryExists(artifactsDir);
-    Information("Running tasks...");
+	Information("Running tasks...");
 });
 
 Teardown(ctx =>
 {
-    // Executed AFTER the last task.
-    Information("Finished running tasks.");
+	// Executed AFTER the last task.
+	Information("Finished running tasks.");
 });
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -127,222 +127,222 @@ Teardown(ctx =>
 ///////////////////////////////////////////////////////////////////////////////
 
 Task("Clean")
-    .Description("Cleans all directories that are used during the build process.")
-    .Does(() =>
-    {
-        foreach(var solution in solutions)
-        {
-            Information("Cleaning {0}", solution.FullPath);
-            CleanDirectories(sourceDir.Path + "/**/bin/*");
-            CleanDirectories(sourceDir.Path + "/**/obj/*");
-            CleanDirectories(testsDir.Path + "/**/bin/*");
-            CleanDirectories(testsDir.Path + "/**/obj/*");
-            Information("{0} was clean.", solution.FullPath);
-        }
+	.Description("Cleans all directories that are used during the build process.")
+	.Does(() =>
+	{
+		foreach(var solution in solutions)
+		{
+			Information("Cleaning {0}", solution.FullPath);
+			CleanDirectories(sourceDir.Path + "/**/bin/*");
+			CleanDirectories(sourceDir.Path + "/**/obj/*");
+			CleanDirectories(testsDir.Path + "/**/bin/*");
+			CleanDirectories(testsDir.Path + "/**/obj/*");
+			Information("{0} was clean.", solution.FullPath);
+		}
 
-        CleanDirectory(artifactsDir);
-    });
+		CleanDirectory(artifactsDir);
+	});
 
 
 Task("Restore")
 	.Description("Restores all the NuGet packages that are used by the specified solution.")
-	.Does(() => 
-    {
-		var settings = new NuGetRestoreSettings 
-		{ 
+	.Does(() =>
+	{
+		var settings = new NuGetRestoreSettings
+		{
 			MSBuildVersion = NuGetMSBuildVersion.MSBuild14,
 			NoCache = true,
 			Verbosity = NuGetVerbosity.Normal
 		};
-        
-        foreach(var solution in solutions)
-        {
-            Information("Restoring NuGet packages for '{0}'...", solution);
+
+		foreach(var solution in solutions)
+		{
+			Information("Restoring NuGet packages for '{0}'...", solution);
 			NuGetRestore(solution, settings);
-            Information("NuGet packages restored for '{0}'.", solution);
-        }
-    });
+			Information("NuGet packages restored for '{0}'.", solution);
+		}
+	});
 
 Task("SemVer")
-    .Description("Applies the SemVer to all the different parts of the project.")
-    .Does(() =>
-    {
-        var settings = new GitVersionSettings 
-        {
-            UpdateAssemblyInfo = true
-        };
+	.Description("Applies the SemVer to all the different parts of the project.")
+	.Does(() =>
+	{
+		var settings = new GitVersionSettings
+		{
+			UpdateAssemblyInfo = true
+		};
 
 		Information("Applying SemVer.");
-        gitVersion = GitVersion(settings);
+		gitVersion = GitVersion(settings);
 		Information("SemVer has been applied.");
-    });
+	});
 
 Task("Build")
 	.Description("Builds all the different parts of the project.")
-	.Does(() => 
-    {
+	.Does(() =>
+	{
 		Build(PlatformTarget.MSIL);
 		Build(PlatformTarget.x64);
-    });
+	});
 
 Task("Test-Unit")
-    .Description("Runs all your unit tests, using dotnet CLI.")
-    .Does(() => 
-	{ 
+	.Description("Runs all your unit tests, using dotnet CLI.")
+	.Does(() =>
+	{
 		var unitTestsProjects = $"./tests/**/bin/{configuration}/**/*.Tests.Unit.dll";
-		Test(unitTestsProjects); 
+		Test(unitTestsProjects);
 
 		unitTestsProjects = $"./tests/**/bin/x64/{configuration}/**/*.Tests.Unit.dll";
-		Test(unitTestsProjects); 
+		Test(unitTestsProjects);
 	});
 
 Task("Dependencies-Analyse")
-    .Description("Runs the Dependencies Analyser on the solution.")
-    .Does(() => 
-    {
-        var settings = new DependenciesAnalyserSettings
-        {
-            Folder = "./src/"
-        };
+	.Description("Runs the Dependencies Analyser on the solution.")
+	.Does(() =>
+	{
+		var settings = new DependenciesAnalyserSettings
+		{
+			Folder = "./src/"
+		};
 
-        Information("Analysing dependencies on folder '{0}'...", sourceDir.Path);
-        AnalyseDependencies(settings);
-        Information("'{0}' dependencies for the projects had been analysed.", sourceDir.Path);
-    });
+		Information("Analysing dependencies on folder '{0}'...", sourceDir.Path);
+		AnalyseDependencies(settings);
+		Information("'{0}' dependencies for the projects had been analysed.", sourceDir.Path);
+	});
 
 Task("AppVeyor-Pack")
-    .Description("Prepares to pack the project, using AppVeyor.")
-    .Does(() =>
-    {
-        var tagBuildEnvVar = EnvironmentVariable("APPVEYOR_REPO_TAG");
-        bool.TryParse(tagBuildEnvVar, out createPackage);
-    });
+	.Description("Prepares to pack the project, using AppVeyor.")
+	.Does(() =>
+	{
+		var tagBuildEnvVar = EnvironmentVariable("APPVEYOR_REPO_TAG");
+		bool.TryParse(tagBuildEnvVar, out createPackage);
+	});
 
 Task("Local-Pack")
-    .Description("Prepares to pack the project, using local environment.")
-    .Does(() =>
-    {
-        createPackage = true;
-    });
+	.Description("Prepares to pack the project, using local environment.")
+	.Does(() =>
+	{
+		createPackage = true;
+	});
 
 Task("Pack")
 	.Description("Packs all the different parts of the project.")
-	.Does(() => 
-    {
-        if(!createPackage)
-        {
-            Information("Skipping the Zip pack step.");
-            return;
-        }
+	.Does(() =>
+	{
+		if(!createPackage)
+		{
+			Information("Skipping the Zip pack step.");
+			return;
+		}
 
 		var patternFolder = "./src/NppXmlTreeviewPlugin/bin/{0}/";
 		var patternOutput = "{0}/NppXMLTreeViewPlugin_{1}.zip";
 		var platform = "x86";
 
-        Pack(
+		Pack(
 		  string.Format(patternFolder, configuration),
 		  string.Format(patternOutput, artifactsDir.Path, platform));
 
 		patternFolder = "./src/NppXmlTreeviewPlugin/bin/x64/{0}/";
 		platform = "x64";
 
-        Pack(
+		Pack(
 		  string.Format(patternFolder, configuration),
 		  string.Format(patternOutput, artifactsDir.Path, platform));
-    });
+	});
 
 Task("Local-Deploy")
-    .Description("Deploys the puglin, using local environment.")
-    .Does(() =>
-    {
-        var patternFolder = "./src/NppXmlTreeviewPlugin/bin/{0}/";
+	.Description("Deploys the puglin, using local environment.")
+	.Does(() =>
+	{
+		var patternFolder = "./src/NppXmlTreeviewPlugin/bin/{0}/";
 
 		CopyPlugin(
 		  string.Format(patternFolder, configuration),
 		  @"C:\Program Files (x86)\Notepad++\plugins");
 
 		patternFolder = "./src/NppXmlTreeviewPlugin/bin/x64/{0}/";
-		
+
 		CopyPlugin(
 		  string.Format(patternFolder, configuration),
 		  @"C:\Program Files\Notepad++\plugins");
-    });
+	});
 
 ///////////////////////////////////////////////////////////////////////////////
 // COMBINATIONS - let's make life easier...
 ///////////////////////////////////////////////////////////////////////////////
 
 Task("Build+Test")
-    .Description("First runs Build, then Test targets.")
-    .IsDependentOn("Clean")
-    .IsDependentOn("Restore")
-    .IsDependentOn("SemVer")
-    .IsDependentOn("Build")
-    .IsDependentOn("Test-Unit")
-    .Does(() => { Information("Ran Build+Test target"); });
+	.Description("First runs Build, then Test targets.")
+	.IsDependentOn("Clean")
+	.IsDependentOn("Restore")
+	.IsDependentOn("SemVer")
+	.IsDependentOn("Build")
+	.IsDependentOn("Test-Unit")
+	.Does(() => { Information("Ran Build+Test target"); });
 
 Task("Rebuild")
-    .Description("Runs a full Clean+Restore+Build build.")
-    .IsDependentOn("Clean")
-    .IsDependentOn("Restore")
-    .IsDependentOn("SemVer")
-    .IsDependentOn("Build")
-    .Does(() => { Information("Rebuilt everything"); });
+	.Description("Runs a full Clean+Restore+Build build.")
+	.IsDependentOn("Clean")
+	.IsDependentOn("Restore")
+	.IsDependentOn("SemVer")
+	.IsDependentOn("Build")
+	.Does(() => { Information("Rebuilt everything"); });
 
 Task("Test-All")
-    .Description("Runs all your tests.")
-    .IsDependentOn("Test-Unit")
-    .Does(() => { Information("Tested everything"); });
+	.Description("Runs all your tests.")
+	.IsDependentOn("Test-Unit")
+	.Does(() => { Information("Tested everything"); });
 
 Task("Analyse")
-    .Description("Analyse the solution.")
-    .IsDependentOn("Build+Test")
-    .IsDependentOn("Dependencies-Analyse")
-    .Does(() => { Information("Analyses done"); });    
+	.Description("Analyse the solution.")
+	.IsDependentOn("Build+Test")
+	.IsDependentOn("Dependencies-Analyse")
+	.Does(() => { Information("Analyses done"); });
 
 Task("LocalPack")
-    .Description("Runs locally.")
-    .IsDependentOn("Clean")
-    .IsDependentOn("Restore")
-    .IsDependentOn("SemVer")
-    .IsDependentOn("Build")
-    .IsDependentOn("Test-Unit")
-    //.IsDependentOn("Dependencies-Analyse")
-    .IsDependentOn("Local-Pack")
-    .IsDependentOn("Pack")
-    .Does(() => { Information("Everything is done! Well done Local Pack."); }); 
+	.Description("Runs locally.")
+	.IsDependentOn("Clean")
+	.IsDependentOn("Restore")
+	.IsDependentOn("SemVer")
+	.IsDependentOn("Build")
+	.IsDependentOn("Test-Unit")
+	//.IsDependentOn("Dependencies-Analyse")
+	.IsDependentOn("Local-Pack")
+	.IsDependentOn("Pack")
+	.Does(() => { Information("Everything is done! Well done Local Pack."); });
 
 Task("LocalDeploy")
-    .Description("Runs locally.")
-    .IsDependentOn("Clean")
-    .IsDependentOn("Restore")
-    .IsDependentOn("SemVer")
-    .IsDependentOn("Build")
-    .IsDependentOn("Test-Unit")
-    //.IsDependentOn("Dependencies-Analyse")
-    .IsDependentOn("Local-Deploy")
-    .Does(() => { Information("Everything is done! Well done Local Deploy."); });
+	.Description("Runs locally.")
+	.IsDependentOn("Clean")
+	.IsDependentOn("Restore")
+	.IsDependentOn("SemVer")
+	.IsDependentOn("Build")
+	.IsDependentOn("Test-Unit")
+	//.IsDependentOn("Dependencies-Analyse")
+	.IsDependentOn("Local-Deploy")
+	.Does(() => { Information("Everything is done! Well done Local Deploy."); });
 
 Task("AppVeyor")
-    .Description("Runs on AppVeyor after 'merging master'.")
-    .IsDependentOn("Clean")
-    .IsDependentOn("Restore")
-    .IsDependentOn("SemVer")
-    .IsDependentOn("Build")
-    .IsDependentOn("Test-Unit")
-    //.IsDependentOn("Dependencies-Analyse")
-    .IsDependentOn("AppVeyor-Pack")
-    .IsDependentOn("Pack")
-    .Does(() => { Information("Everything is done! Well done AppVeyor."); });
+	.Description("Runs on AppVeyor after 'merging master'.")
+	.IsDependentOn("Clean")
+	.IsDependentOn("Restore")
+	.IsDependentOn("SemVer")
+	.IsDependentOn("Build")
+	.IsDependentOn("Test-Unit")
+	//.IsDependentOn("Dependencies-Analyse")
+	.IsDependentOn("AppVeyor-Pack")
+	.IsDependentOn("Pack")
+	.Does(() => { Information("Everything is done! Well done AppVeyor."); });
 
 ///////////////////////////////////////////////////////////////////////////////
 // DEFAULT TARGET
 ///////////////////////////////////////////////////////////////////////////////
 
 Task("Default")
-    .Description("This is the default task which will run if no specific target is passed in.")
-    .IsDependentOn("Build+Test")
-    .Does(() => { Warning("No 'Target' was passed in, so we ran the 'Build+Test' operation."); });
+	.Description("This is the default task which will run if no specific target is passed in.")
+	.IsDependentOn("Build+Test")
+	.Does(() => { Warning("No 'Target' was passed in, so we ran the 'Build+Test' operation."); });
 
 ///////////////////////////////////////////////////////////////////////////////
 // EXECUTION

--- a/build.ps1
+++ b/build.ps1
@@ -85,7 +85,7 @@ function GetProxyEnabledWebClient
 {
     $wc = New-Object System.Net.WebClient
     $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
-    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials        
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
     $wc.Proxy = $proxy
     return $wc
 }
@@ -115,8 +115,8 @@ if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
 
 # Make sure that packages.config exist.
 if (!(Test-Path $PACKAGES_CONFIG)) {
-    Write-Verbose -Message "Downloading packages.config..."    
-    try {        
+    Write-Verbose -Message "Downloading packages.config..."
+    try {
         $wc = GetProxyEnabledWebClient
         $wc.DownloadFile("https://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
         Throw "Could not download packages.config."

--- a/src/NppXmlTreeviewPlugin.Parsers/NppXmlTreeviewPlugin.Parsers.csproj
+++ b/src/NppXmlTreeviewPlugin.Parsers/NppXmlTreeviewPlugin.Parsers.csproj
@@ -53,9 +53,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog">
-      <HintPath>..\..\packages\Serilog.2.6.0\lib\net46\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/NppXmlTreeviewPlugin.Parsers/packages.config
+++ b/src/NppXmlTreeviewPlugin.Parsers/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="2.6.0" targetFramework="net461" />
+  <package id="Serilog" version="2.10.0" targetFramework="net461" />
 </packages>

--- a/src/NppXmlTreeviewPlugin/NppXmlTreeviewPlugin.csproj
+++ b/src/NppXmlTreeviewPlugin/NppXmlTreeviewPlugin.csproj
@@ -63,12 +63,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog">
-      <HintPath>..\..\packages\Serilog.2.6.0\lib\net46\Serilog.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Sinks.File.3.2.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.Sinks.File.4.1.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.RollingFile">
       <HintPath>..\..\packages\Serilog.Sinks.RollingFile.3.3.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>

--- a/src/NppXmlTreeviewPlugin/packages.config
+++ b/src/NppXmlTreeviewPlugin/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="2.6.0" targetFramework="net461" />
-  <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net461" />
+  <package id="Serilog" version="2.10.0" targetFramework="net461" />
+  <package id="Serilog.Sinks.File" version="4.1.0" targetFramework="net461" />
   <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net461" />
 </packages>

--- a/tests/NppXmlTreeviewPlugin.Parsers.Tests.Unit/NppXmlTreeviewPlugin.Parsers.Tests.Unit.csproj
+++ b/tests/NppXmlTreeviewPlugin.Parsers.Tests.Unit/NppXmlTreeviewPlugin.Parsers.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -52,16 +52,17 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=5.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.5.3.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=5.10.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.5.10.3\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.6.0\lib\net46\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -70,16 +71,16 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.4.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -93,12 +94,6 @@
       <Project>{eaba4132-6e8c-41ec-b6f0-666efca5439a}</Project>
       <Name>NppXmlTreeviewPlugin.Parsers</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\..\packages\xunit.analyzers.0.8.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestFiles\invalid_comments.xml">
@@ -117,15 +112,21 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props'))" />
   </Target>
-  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
+  <Import Project="..\..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
 </Project>

--- a/tests/NppXmlTreeviewPlugin.Parsers.Tests.Unit/app.config
+++ b/tests/NppXmlTreeviewPlugin.Parsers.Tests.Unit/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/NppXmlTreeviewPlugin.Parsers.Tests.Unit/packages.config
+++ b/tests/NppXmlTreeviewPlugin.Parsers.Tests.Unit/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="5.3.0" targetFramework="net461" />
-  <package id="Serilog" version="2.6.0" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-  <package id="xunit" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
-  <package id="xunit.analyzers" version="0.8.0" targetFramework="net461" />
-  <package id="xunit.assert" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.core" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net461" developmentDependency="true" />
+  <package id="FluentAssertions" version="5.10.3" targetFramework="net461" />
+  <package id="Serilog" version="2.10.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+  <package id="xunit" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net461" />
+  <package id="xunit.analyzers" version="0.10.0" targetFramework="net461" />
+  <package id="xunit.assert" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.core" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net461" />
+  <package id="xunit.runner.visualstudio" version="2.4.3" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- updated nuget packages with VS2017
- use VS2017 for builds
- add github actions showing that VS2019 could be used

Issue:
- updating appveyor image to VS2019 breaks with an issue in finding msbuild, see e.g. https://ci.appveyor.com/project/chcg/nppxmltreeview/builds/37288739

@joaoasrosa To some degree I could take over the maintenance of this plugin. Meaning updating the nuget packages, build tooling and keep it running. Maybe do some smaller, simple fixes. I will not be able to do new feature development.